### PR TITLE
Fix shebang in commit_release.sh

### DIFF
--- a/.github/scripts/commit_release.sh
+++ b/.github/scripts/commit_release.sh
@@ -1,4 +1,4 @@
- #!/bin/bash
+#!/bin/bash
 
 set -e -o pipefail
 


### PR DESCRIPTION
The shebang had a space before it. Fixed it to try to ensure we run the script as bash.