### PR TITLE
MINF-2398 Specify collectionSize for collections

### DIFF
--- a/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
+++ b/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
@@ -68,8 +68,8 @@ private const val DEFAULT_COLLECTION_SIZE = 3
  *     specify a consistent value for this field.
  * @param useNullForNullableFields If true, then all fields that are nullable will be set to null,
  *     unless specified in the overrides map.
- * @param collectionSize If specified, supported collection types will be set to that size rather
- *     than
+ * @param collectionSize If specified, supported collection types will be set to the specified
+ *     size rather than the default of size 3
  * @return The generated object.
  */
 fun <T : Any> KClass<T>.generateTestObject(

--- a/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
+++ b/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
@@ -11,6 +11,8 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 import kotlin.reflect.javaType
 
+private const val DEFAULT_COLLECTION_SIZE = 3
+
 /**
  * Generates a test object for the given data class, where each field is given an actual,
  * unique value (as opposed to just some default value like empty string or null).
@@ -66,6 +68,8 @@ import kotlin.reflect.javaType
  *     specify a consistent value for this field.
  * @param useNullForNullableFields If true, then all fields that are nullable will be set to null,
  *     unless specified in the overrides map.
+ * @param collectionSize If specified, supported collection types will be set to that size rather
+ *     than
  * @return The generated object.
  */
 fun <T : Any> KClass<T>.generateTestObject(
@@ -73,7 +77,7 @@ fun <T : Any> KClass<T>.generateTestObject(
     overrides: Map<Regex, Any?>? = null,
     referenceDate: Date? = null,
     useNullForNullableFields: Boolean = false,
-    collectionSize: Int = 3,
+    collectionSize: Int = DEFAULT_COLLECTION_SIZE,
 ): T {
     return generateTestObject(
         prefix,
@@ -81,7 +85,7 @@ fun <T : Any> KClass<T>.generateTestObject(
             overrides,
             referenceDate,
             useNullForNullableFields,
-            collectionSize, // TODO enforce size >= 1
+            collectionSize.takeIf { it > 0 } ?: DEFAULT_COLLECTION_SIZE,
         )
     )
 }

--- a/library/src/jvmTest/kotlin/com/thumbtack/kotlin/test/GenerateTestObjectTest.kt
+++ b/library/src/jvmTest/kotlin/com/thumbtack/kotlin/test/GenerateTestObjectTest.kt
@@ -13,6 +13,8 @@ class GenerateTestObjectTest {
         val booleanField: Boolean,
         val charField: Char,
         val listField: List<String>,
+        val setField: Set<String>,
+        val mapField: Map<String, String>,
         val intArray: IntArray,
         val floatArray: FloatArray,
         val doubleArray: DoubleArray,
@@ -49,5 +51,15 @@ class GenerateTestObjectTest {
         assertTrue(testObject.byteArray.all { it == 0.toByte() })
         assertEquals(3, testObject.booleanArray.size)
         assertTrue(testObject.booleanArray.all { !it })
+    }
+
+    @Test
+    fun `test collectionSize`() {
+        val collectionSize = 5
+        val testObject = SampleClass::class.generateTestObject(collectionSize = collectionSize)
+
+        assertEquals(collectionSize, testObject.listField.size)
+        assertEquals(collectionSize, testObject.setField.size)
+        assertEquals(collectionSize, testObject.mapField.size)
     }
 }


### PR DESCRIPTION
Adds a new parameter for generateTestObject() to specify collection size.

Should the arrays in generateValueForSimpleField() also account for this parameter?