### PR TITLE
Remove duplicate when statement for ArrayList

### DIFF
--- a/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
+++ b/library/src/jvmMain/kotlin/com/thumbtack/kotlin/test/GenerateTestObject.kt
@@ -168,14 +168,6 @@ private fun generateValueForParameterizedType(
                         params,
                     )
                 }.toSet()
-            ArrayList::class.java ->
-                return List(collectionSize) { index ->
-                    generateValueForField(
-                        generateFieldType(type),
-                        "$prefix$index",
-                        params,
-                    )
-                }
             java.util.Map::class.java ->
                 return (0..< collectionSize).associate { index ->
                     generateValueForField(


### PR DESCRIPTION
We already handle ArrayList::class.java at the beginning of the when statement.  I'm surprised we don't get warnings about this from AS.